### PR TITLE
refactoring ApplicationViews to use React fragments

### DIFF
--- a/src/components/ApplicationViews.js
+++ b/src/components/ApplicationViews.js
@@ -184,12 +184,16 @@ class ApplicationViews extends Component {
                     path="/clients"
                     render={props => {
                         return this.isAuthenticated() ? (
-                            <ClientList
-                                {...props}
-                                clients={this.state.clients}
-                                deleteClient={this.deleteClient}
-                            />
-                        ) : (
+                            <React.Fragment>
+                                <NavBar />
+                                <ClientList
+                                    {...props}
+                                    clients={this.state.clients}
+                                    deleteClient={this.deleteClient}
+                                />
+                            </React.Fragment>
+                        ) 
+                        : (
                                 <Redirect to="/login" />
                             );
                     }}
@@ -199,10 +203,14 @@ class ApplicationViews extends Component {
                     exact path="/clients/new"
                     render={(props) => {
                         return this.isAuthenticated() ? (
-                            <ClientForm {...props}
-                                addClient={this.addClient}
-                                clients={this.state.clients} />
-                        ) : (
+                            <React.Fragment>
+                                <NavBar />
+                                <ClientForm {...props}
+                                    addClient={this.addClient}
+                                    clients={this.state.clients} />
+                            </React.Fragment>
+                            ) 
+                            : (
                                 <Redirect to="/login" />
                             )
                     }} />


### PR DESCRIPTION
Routes use <React.Fragment> 's in ApplicationViews.js now, as a way to hide the nav bar when a user is not signed in.